### PR TITLE
Forward2Rotation Fix

### DIFF
--- a/Assets/Libs/Helpers.cs
+++ b/Assets/Libs/Helpers.cs
@@ -26,13 +26,9 @@ namespace Libs
             return new Vector3(floats[0], floats[1], floats[2]);
         }
 
-        // https://github.com/lexogrine/hud-manager/blob/4a2906b34e5a4bea3ac65ee408124e9ca549650d/boltobserv/modules/gsi.js#L75
         public static Quaternion Forward2Rotation(Vector3 forward)
         {
-            float angle = forward.x > 0
-                ? 90 + (forward.y * -1 * 90)
-                : 270 + (forward.y * 90)
-                ;
+            float angle = Mathf.Atan2(forward.x, forward.y) * Mathf.Rad2Deg *-1;
 
             return Quaternion.Euler(0, 0, angle);
         }


### PR DESCRIPTION
Tested two demos shortly and they seemed to be totally fine.

Edit for those who are interested in GSI projects:
The old method works if the map is flat and not in a 90° angle like a normal UI would be.
Here a screenshot example of a 3D version I'm working on, which needs the previous forward2rotation method. 
![image](https://github.com/n1c/csgo-gsi-radar-unity/assets/30211694/e6afe9c3-d6c4-4133-bf88-ddc163921009)